### PR TITLE
Show nearby depots

### DIFF
--- a/src/main/java/bike/guyona/exdepot/ExDepotMod.java
+++ b/src/main/java/bike/guyona/exdepot/ExDepotMod.java
@@ -29,7 +29,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.util.thread.EffectiveSide;
@@ -151,11 +150,6 @@ public class ExDepotMod {
     @SubscribeEvent
     static void onCommonSetup(FMLCommonSetupEvent event) {
         LOGGER.info("First: I am on side {}, second: Update log4j to >= 2.16", EffectiveSide.get());
-    }
-
-    @SubscribeEvent
-    static void onClientSetup(FMLClientSetupEvent event) {
-        // TODO: remove unused handler
     }
 
     // TODO: The docs are insistent that this code be isolated in a client-only area.

--- a/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
+++ b/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
@@ -33,13 +33,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-import static bike.guyona.exdepot.events.EventHandler.VIEWABLE_CONFIG_REFRESH_INTERVAL_MS;
+import static bike.guyona.exdepot.network.ViewDepotsCacheWhisperer.VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
 import static net.minecraft.SharedConstants.TICKS_PER_SECOND;
 
 
 // Some from https://github.com/longbowrocks/ExplorersDepot/compare/master...view_config_without_opening_it#diff-6bcbfc776a0b95590c9f26a81d340db82563cdfdf573b37e4a47e38e6d2b0b77R203
 @OnlyIn(Dist.CLIENT)
 public class ViewDepotParticle extends Particle {
+    private static final double EAST_OFFSET = 0.5;
+    private static final double NORTH_OFFSET = 0.5;
+    private static final double UP_OFFSET = 2.0;
+
     private final String modId;
     private final boolean simpleDepot;
     private final ChestFullness chestFullness;
@@ -47,16 +51,16 @@ public class ViewDepotParticle extends Particle {
     private ResourceLocation logoPath;
 
     public ViewDepotParticle(ClientLevel level, double x, double y, double z, String modId, boolean simpleDepot, ChestFullness chestFullness) {
-        super(level, x, y, z);
+        super(level, x + EAST_OFFSET, y + UP_OFFSET, z + NORTH_OFFSET);
         this.modId = modId;
         this.simpleDepot = simpleDepot;
         this.chestFullness = chestFullness;
         this.setSize(2,2);
         updateCache();
 
-        final int GET_DEPOTS_LATENCY_TICKS = 1;
+        final int GET_DEPOTS_LATENCY_TICKS = 40; // There can be high server latency, but this also accounts for delayed ticks at client startup.
         final int MS_PER_SECOND = 1000;
-        this.lifetime = VIEWABLE_CONFIG_REFRESH_INTERVAL_MS / MS_PER_SECOND * TICKS_PER_SECOND + GET_DEPOTS_LATENCY_TICKS;
+        this.lifetime = VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS / MS_PER_SECOND * TICKS_PER_SECOND + GET_DEPOTS_LATENCY_TICKS;
         this.gravity = 0.0F;
     }
 
@@ -220,5 +224,9 @@ public class ViewDepotParticle extends Particle {
                 this.getPixels().upload(0, 0, 0, 0, 0, td.getWidth(), td.getHeight(), selectedMod.getLogoBlur(), false, false, false);
             }
         });
+    }
+
+    public void resetAge() {
+        this.age = 0;
     }
 }

--- a/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
+++ b/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+import static bike.guyona.exdepot.events.EventHandler.VIEWABLE_CONFIG_REFRESH_INTERVAL_MS;
 import static net.minecraft.SharedConstants.TICKS_PER_SECOND;
 
 
@@ -53,7 +54,9 @@ public class ViewDepotParticle extends Particle {
         this.setSize(2,2);
         updateCache();
 
-        this.lifetime = 5*TICKS_PER_SECOND;
+        final int GET_DEPOTS_LATENCY_TICKS = 1;
+        final int MS_PER_SECOND = 1000;
+        this.lifetime = VIEWABLE_CONFIG_REFRESH_INTERVAL_MS / MS_PER_SECOND * TICKS_PER_SECOND + GET_DEPOTS_LATENCY_TICKS;
         this.gravity = 0.0F;
     }
 

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -32,7 +32,7 @@ public class EventHandler {
     // playerID -> BlockPos -> depotCacheCompoundTag.
     // Technically key should include level, but one player can't leftclick a block in two levels in one tick.
     private static final Map<Integer, Map<BlockPos, CompoundTag>> pickedUpDepotCache = new HashMap<>();
-    private static final int VIEWABLE_CONFIG_REFRESH_INTERVAL_MS = 1000;
+    public static final int VIEWABLE_CONFIG_REFRESH_INTERVAL_MS = 1000;
 
     @SubscribeEvent
     static void onClientTick(TickEvent.ClientTickEvent event) {

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -29,9 +29,10 @@ import static bike.guyona.exdepot.ExDepotMod.*;
 public class EventHandler {
     public static final DepositItemsJuice JUICER = new DepositItemsJuice();
     private static long lastUpdatedViewableConfigs = 0;
+    // playerID -> BlockPos -> depotCacheCompoundTag.
     // Technically key should include level, but one player can't leftclick a block in two levels in one tick.
     private static final Map<Integer, Map<BlockPos, CompoundTag>> pickedUpDepotCache = new HashMap<>();
-    private static final int VIEWABLE_CONFIG_REFRESH_INTERVAL_MS = 5000;
+    private static final int VIEWABLE_CONFIG_REFRESH_INTERVAL_MS = 1000;
 
     @SubscribeEvent
     static void onClientTick(TickEvent.ClientTickEvent event) {

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -4,43 +4,47 @@ import bike.guyona.exdepot.Ref;
 import bike.guyona.exdepot.capabilities.DepotCapabilityProvider;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
 import bike.guyona.exdepot.client.DepositItemsJuice;
+import bike.guyona.exdepot.network.ViewDepotsCacheWhisperer;
 import bike.guyona.exdepot.network.ViewDepotsMessage;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import static bike.guyona.exdepot.ExDepotMod.*;
 
 
-@Mod.EventBusSubscriber(modid = Ref.MODID, value = Dist.CLIENT)
+@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class EventHandler {
     public static final DepositItemsJuice JUICER = new DepositItemsJuice();
-    private static long lastUpdatedViewableConfigs = 0;
+    public static final ViewDepotsCacheWhisperer VIEW_DEPOTS_CACHE_WHISPERER = new ViewDepotsCacheWhisperer();
     // playerID -> BlockPos -> depotCacheCompoundTag.
     // Technically key should include level, but one player can't leftclick a block in two levels in one tick.
     private static final Map<Integer, Map<BlockPos, CompoundTag>> pickedUpDepotCache = new HashMap<>();
-    public static final int VIEWABLE_CONFIG_REFRESH_INTERVAL_MS = 1000;
 
     @SubscribeEvent
     static void onClientTick(TickEvent.ClientTickEvent event) {
         JUICER.handleClientTick();
-        long curTime = System.currentTimeMillis();
-        if (isIngame() && curTime > lastUpdatedViewableConfigs + VIEWABLE_CONFIG_REFRESH_INTERVAL_MS) {
-            NETWORK_INSTANCE.sendToServer(new ViewDepotsMessage());
-            lastUpdatedViewableConfigs = curTime;
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null && player.getMainHandItem().getItem().equals(WAND_ITEM.get())) {
+            if (isIngame() && VIEW_DEPOTS_CACHE_WHISPERER.isUpdateDue()) {
+                NETWORK_INSTANCE.sendToServer(new ViewDepotsMessage());
+                VIEW_DEPOTS_CACHE_WHISPERER.setUpdated();
+            }
+        }else {
+            VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(new ArrayList<>());
         }
     }
 

--- a/src/main/java/bike/guyona/exdepot/helpers/ChestFullness.java
+++ b/src/main/java/bike/guyona/exdepot/helpers/ChestFullness.java
@@ -1,7 +1,37 @@
 package bike.guyona.exdepot.helpers;
 
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+
 public enum ChestFullness {
     EMPTY,
     FILLING,
-    FULL
+    FULL;
+
+    /**
+     * @param chest
+     * @return fullness. A chest can have room (EMPTY), have 80% slots full (FILLING), or have 100% slots full (FULL)
+     */
+    public static ChestFullness getChestFullness(BlockEntity chest) {
+        LazyOptional<IItemHandler> lazyItemHandler = chest.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.UP);
+        if (!lazyItemHandler.isPresent()) {
+            return ChestFullness.EMPTY;
+        }
+        IItemHandler itemHandler = lazyItemHandler.orElse(null);
+        int filledSlots = 0;
+        for (int i=0; i < itemHandler.getSlots(); i++) {
+            if (!itemHandler.getStackInSlot(i).isEmpty())
+                filledSlots += 1;
+        }
+        float pctFull = (float) filledSlots / (float) itemHandler.getSlots();
+        if (pctFull < 0.8) {
+            return ChestFullness.EMPTY;
+        } else if (pctFull < 1) {
+            return ChestFullness.FILLING;
+        }
+        return ChestFullness.FULL;
+    }
 }

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotSummary.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotSummary.java
@@ -1,0 +1,23 @@
+package bike.guyona.exdepot.network;
+
+import bike.guyona.exdepot.capabilities.IDepotCapability;
+import bike.guyona.exdepot.helpers.ChestFullness;
+import bike.guyona.exdepot.sortingrules.mod.ModSortingRule;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.Set;
+
+public record ViewDepotSummary(@NotNull BlockPos loc, @NotNull String modId, boolean isSimpleDepot, @NotNull ChestFullness chestFullness) {
+    public static ViewDepotSummary fromDepot(BlockEntity chest, IDepotCapability cap) {
+        BlockPos loc = chest.getBlockPos();
+        Set<ModSortingRule> modRules = cap.getRules(ModSortingRule.class);
+        Optional<String> modIdOptional = modRules.stream().map(ModSortingRule::getModId).findFirst();
+        String modId = modIdOptional.orElse("");
+        boolean isSimpleDepot = modRules.size() == 1 && cap.size() == 1;
+        ChestFullness chestFullness = ChestFullness.getChestFullness(chest);
+        return new ViewDepotSummary(loc, modId, isSimpleDepot, chestFullness);
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotsCacheWhisperer.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotsCacheWhisperer.java
@@ -1,0 +1,80 @@
+package bike.guyona.exdepot.network;
+
+import bike.guyona.exdepot.client.particles.ViewDepotParticle;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ViewDepotsCacheWhisperer {
+    public static final int VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS = 1000;
+    private static long lastUpdatedViewableConfigs = 0;
+    private List<ViewDepotSummary> depotSummaries = new ArrayList<>();
+    private final List<ViewDepotParticle> depotParticles = new ArrayList<>();
+
+    public boolean isUpdateDue() {
+        return System.currentTimeMillis() > lastUpdatedViewableConfigs + VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
+    }
+
+    public void setUpdated() {
+        lastUpdatedViewableConfigs = System.currentTimeMillis();
+    }
+
+    public boolean areSummariesChanged(@NotNull List<ViewDepotSummary> depotSummaries) {
+        if (this.depotSummaries.size() != depotSummaries.size()) {
+            return true;
+        }
+        sortSummaries(depotSummaries);
+        for (int i=0; i<depotSummaries.size(); i++) {
+            if (!this.depotSummaries.get(i).equals(depotSummaries.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void resetParticleLifetimes() {
+        for (ViewDepotParticle particle : depotParticles) {
+            particle.resetAge();
+        }
+    }
+
+    public void replaceParticles(@NotNull List<ViewDepotSummary> depotSummaries) {
+        // Out with the old
+        for (ViewDepotParticle particle : depotParticles) {
+            particle.remove();
+        }
+        depotParticles.clear();
+        this.depotSummaries.clear();
+        // In with the new
+        Minecraft minecraft = Minecraft.getInstance();
+        this.depotSummaries = depotSummaries;
+        sortSummaries(this.depotSummaries);
+        for (ViewDepotSummary depotSummary : this.depotSummaries) {
+            ViewDepotParticle particle = new ViewDepotParticle(
+                    minecraft.level,
+                    depotSummary.loc().getX(),
+                    depotSummary.loc().getY(),
+                    depotSummary.loc().getZ(),
+                    depotSummary.modId(),
+                    depotSummary.isSimpleDepot(),
+                    depotSummary.chestFullness()
+            );
+            depotParticles.add(particle);
+            minecraft.particleEngine.add(particle);
+        }
+    }
+
+    private void sortSummaries(@NotNull List<ViewDepotSummary> depotSummaries) {
+        depotSummaries.sort((ViewDepotSummary pos1, ViewDepotSummary pos2) -> {
+            if (pos1.loc().getY() != pos2.loc().getY()) {
+                return Integer.compare(pos1.loc().getY(), pos2.loc().getY());
+            } else if (pos1.loc().getX() != pos2.loc().getX()) {
+                return Integer.compare(pos1.loc().getX(), pos2.loc().getX());
+            } else {
+                return Integer.compare(pos1.loc().getZ(), pos2.loc().getZ());
+            }
+        });
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotsMessage.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotsMessage.java
@@ -3,21 +3,16 @@ package bike.guyona.exdepot.network;
 import bike.guyona.exdepot.ExDepotMod;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
 import bike.guyona.exdepot.config.ExDepotConfig;
-import bike.guyona.exdepot.helpers.ChestFullness;
-import bike.guyona.exdepot.sortingrules.mod.ModSortingRule;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.PacketDistributor;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static bike.guyona.exdepot.ExDepotMod.NETWORK_INSTANCE;
@@ -38,22 +33,13 @@ public class ViewDepotsMessage {
         } else {
             ctx.get().enqueueWork(() -> {
                 Vector<BlockEntity> nearbyChests = getLocalChests(sender);
-                AtomicReference<IDepotCapability> nearestConfigWrapped = new AtomicReference<>();
-                if (nearbyChests.size() > 0) {
-                    LazyOptional<IDepotCapability> lazyDepot = nearbyChests.get(0).getCapability(DEPOT_CAPABILITY, Direction.UP);
-                    lazyDepot.ifPresent(nearestConfigWrapped::set);
+                List<ViewDepotSummary> depotSummaries = new ArrayList<>();
+                for (BlockEntity chest : nearbyChests) {
+                    chest.getCapability(DEPOT_CAPABILITY, Direction.UP).ifPresent((cap) -> {
+                        depotSummaries.add(ViewDepotSummary.fromDepot(chest, cap));
+                    });
                 }
-                if (nearestConfigWrapped.get() == null) {
-                    NETWORK_INSTANCE.send(PacketDistributor.PLAYER.with(() -> sender), new ViewDepotsResponse(null, null, false, ChestFullness.EMPTY));
-                } else {
-                    BlockEntity nearestChest = nearbyChests.get(0);
-                    Set<ModSortingRule> modRules = nearestConfigWrapped.get().getRules(ModSortingRule.class);
-                    Optional<String> modIdOptional = modRules.stream().map(ModSortingRule::getModId).findFirst();
-                    String modId = modIdOptional.orElse(null);
-                    boolean simpleDepot = modRules.size() == 1 && nearestConfigWrapped.get().size() == 1;
-                    ChestFullness chestFullness = getChestFullness(nearestChest);
-                    NETWORK_INSTANCE.send(PacketDistributor.PLAYER.with(() -> sender), new ViewDepotsResponse(nearestChest.getBlockPos(), modId, simpleDepot, chestFullness));
-                }
+                NETWORK_INSTANCE.send(PacketDistributor.PLAYER.with(() -> sender), new ViewDepotsResponse(depotSummaries));
             });
         }
         ctx.get().setPacketHandled(true);
@@ -62,7 +48,7 @@ public class ViewDepotsMessage {
     private static Vector<BlockEntity> getLocalChests(ServerPlayer player){
         Vector<BlockEntity> chests = new Vector<>();
         int chunkDist = (ExDepotConfig.storeRange.get() / CHUNK_SIZE) + 1;
-        ExDepotMod.LOGGER.info("Storage range is {} blocks, or {} chunks", ExDepotConfig.storeRange.get(), chunkDist);
+        ExDepotMod.LOGGER.debug("Storage range is {} blocks, or {} chunks", ExDepotConfig.storeRange.get(), chunkDist);
         for (int chunkX = player.chunkPosition().x-chunkDist; chunkX <= player.chunkPosition().x+chunkDist; chunkX++) {
             for (int chunkZ = player.chunkPosition().z-chunkDist; chunkZ <= player.chunkPosition().z+chunkDist; chunkZ++) {
                 Collection<BlockEntity> entities = player.level.getChunk(chunkX, chunkZ).getBlockEntities().values();
@@ -80,27 +66,5 @@ public class ViewDepotsMessage {
         return chests;
     }
 
-    /**
-     * @param chest
-     * @return fullness. A chest can have room (0), have 80% slots full (1), or have 100% slots full (2)
-     */
-    private static ChestFullness getChestFullness(BlockEntity chest) {
-        LazyOptional<IItemHandler> lazyItemHandler = chest.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.UP);
-        if (!lazyItemHandler.isPresent()) {
-            return ChestFullness.EMPTY;
-        }
-        IItemHandler itemHandler = lazyItemHandler.orElse(null);
-        int filledSlots = 0;
-        for (int i=0; i < itemHandler.getSlots(); i++) {
-            if (!itemHandler.getStackInSlot(i).isEmpty())
-                filledSlots += 1;
-        }
-        float pctFull = (float) filledSlots / (float) itemHandler.getSlots();
-        if (pctFull < 0.8) {
-            return ChestFullness.EMPTY;
-        } else if (pctFull < 1) {
-            return ChestFullness.FILLING;
-        }
-        return ChestFullness.FULL;
-    }
+
 }

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotsResponse.java
@@ -49,7 +49,7 @@ public class ViewDepotsResponse {
                     ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
                     return;
                 }
-                ExDepotMod.LOGGER.info("Refreshed cache of {} at {}", obj.modId, obj.depotLocation);
+                ExDepotMod.LOGGER.debug("Refreshed cache of {} at {}", obj.modId, obj.depotLocation);
                 Minecraft minecraft = Minecraft.getInstance();
                 minecraft.particleEngine.add(
                         new ViewDepotParticle(

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotsResponse.java
@@ -1,7 +1,7 @@
 package bike.guyona.exdepot.network;
 
 import bike.guyona.exdepot.ExDepotMod;
-import bike.guyona.exdepot.client.particles.ViewDepotParticle;
+import bike.guyona.exdepot.events.EventHandler;
 import bike.guyona.exdepot.helpers.ChestFullness;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -11,34 +11,38 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.NetworkEvent;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class ViewDepotsResponse {
-    BlockPos depotLocation;
-    String modId;
-    boolean simpleDepot;
-    ChestFullness chestFullness;
+    List<ViewDepotSummary> depotSummaries;
 
-    public ViewDepotsResponse(BlockPos loc, String modId, boolean simpleDepot, ChestFullness chestFullness) {
-        this.depotLocation = loc;
-        this.modId = modId;
-        this.simpleDepot = simpleDepot;
-        this.chestFullness = chestFullness;
+    public ViewDepotsResponse(List<ViewDepotSummary> depotSummaries) {
+        this.depotSummaries = depotSummaries;
     }
 
     public void encode(FriendlyByteBuf buf) {
-        buf.writeBlockPos(depotLocation == null ? BlockPos.ZERO : depotLocation);
-        buf.writeUtf(modId == null ? "" : modId);
-        buf.writeBoolean(simpleDepot);
-        buf.writeInt(chestFullness.ordinal());
+        buf.writeInt(depotSummaries.size());
+        for (ViewDepotSummary depotSummary : depotSummaries) {
+            buf.writeBlockPos(depotSummary.loc());
+            buf.writeUtf(depotSummary.modId());
+            buf.writeBoolean(depotSummary.isSimpleDepot());
+            buf.writeInt(depotSummary.chestFullness().ordinal());
+        }
     }
 
     public static ViewDepotsResponse decode(FriendlyByteBuf buf) {
-        BlockPos depotLocation = buf.readBlockPos();
-        String modId = buf.readUtf();
-        boolean simpleDepot = buf.readBoolean();
-        ChestFullness chestFullness = ChestFullness.values()[buf.readInt()];
-        return new ViewDepotsResponse(depotLocation, modId, simpleDepot, chestFullness);
+        List<ViewDepotSummary> summaries = new ArrayList<>();
+        int numSummaries = buf.readInt();
+        for (int i=0; i < numSummaries; i++) {
+            BlockPos depotLocation = buf.readBlockPos();
+            String modId = buf.readUtf();
+            boolean simpleDepot = buf.readBoolean();
+            ChestFullness chestFullness = ChestFullness.values()[buf.readInt()];
+            summaries.add(new ViewDepotSummary(depotLocation, modId, simpleDepot, chestFullness));
+        }
+        return new ViewDepotsResponse(summaries);
     }
 
     public static void handle(ViewDepotsResponse obj, Supplier<NetworkEvent.Context> ctx) {
@@ -49,19 +53,13 @@ public class ViewDepotsResponse {
                     ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
                     return;
                 }
-                ExDepotMod.LOGGER.debug("Refreshed cache of {} at {}", obj.modId, obj.depotLocation);
-                Minecraft minecraft = Minecraft.getInstance();
-                minecraft.particleEngine.add(
-                        new ViewDepotParticle(
-                                minecraft.level,
-                                obj.depotLocation.getX() + 0.5,
-                                obj.depotLocation.getY() + 2.0,
-                                obj.depotLocation.getZ() + 0.5,
-                                obj.modId,
-                                obj.simpleDepot,
-                                obj.chestFullness
-                        )
-                );
+                if (EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.areSummariesChanged(obj.depotSummaries)) {
+                    ExDepotMod.LOGGER.debug("Refreshing ViewDepots cache with {} Depots", obj.depotSummaries.size());
+                    EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(obj.depotSummaries);
+                } else {
+                    ExDepotMod.LOGGER.debug("Reusing existing ViewDepots cache");
+                    EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.resetParticleLifetimes();
+                }
             });
         });
         ctx.get().setPacketHandled(true);


### PR DESCRIPTION
* Shows ALL nearby Depots, but only when you have the Explorer's Wand in your hand.
* Fixed a bug with my Forge event subscriber (EventHandler.java), as I need some of those events on both Dist.CLIENT and Dist.SERVER. This may have introduced new bugs, as I'm not certain all the client-only code is properly protected.
* Minor code cleanup tasks.