### PR TITLE
Better depot viewing

### DIFF
--- a/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
+++ b/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
@@ -149,9 +149,6 @@ public class ViewDepotParticle extends Particle {
     /**
      * Given a point on the particle. Converts these values to the internal coordinate system of
      * the particle (in pixels), and returns a Vec3 with x and y set to the resulting values.
-     * @param x
-     * @param y
-     * @return
      */
     private Vec3 getSeg(double x, double y) {
         x -= 0.5;

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -5,7 +5,6 @@ import bike.guyona.exdepot.capabilities.DepotCapabilityProvider;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
 import bike.guyona.exdepot.client.DepositItemsJuice;
 import bike.guyona.exdepot.network.ViewDepotsCacheWhisperer;
-import bike.guyona.exdepot.network.ViewDepotsMessage;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
@@ -40,10 +39,9 @@ public class EventHandler {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player != null && player.getMainHandItem().getItem().equals(WAND_ITEM.get())) {
             if (isIngame() && VIEW_DEPOTS_CACHE_WHISPERER.isUpdateDue()) {
-                NETWORK_INSTANCE.sendToServer(new ViewDepotsMessage());
-                VIEW_DEPOTS_CACHE_WHISPERER.setUpdated();
+                VIEW_DEPOTS_CACHE_WHISPERER.triggerUpdateFromClient();
             }
-        }else {
+        }else if (VIEW_DEPOTS_CACHE_WHISPERER.isActive()) {
             VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(new ArrayList<>());
         }
     }

--- a/src/main/java/bike/guyona/exdepot/items/DepotConfiguratorWandItem.java
+++ b/src/main/java/bike/guyona/exdepot/items/DepotConfiguratorWandItem.java
@@ -3,12 +3,14 @@ package bike.guyona.exdepot.items;
 import bike.guyona.exdepot.ExDepotMod;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
 import bike.guyona.exdepot.client.gui.DepotRulesScreen;
+import bike.guyona.exdepot.events.EventHandler;
 import bike.guyona.exdepot.sortingrules.SortingRuleProvider;
 import bike.guyona.exdepot.sortingrules.mod.ModSortingRule;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -29,6 +31,11 @@ public class DepotConfiguratorWandItem extends Item {
     @Override
     @MethodsReturnNonnullByDefault
     public InteractionResult useOn(UseOnContext ctx) {
+        Player player = ctx.getPlayer();
+        if (player == null) {
+            ExDepotMod.LOGGER.error("Explorer's Depot wand was use by a non-player? No dice.");
+            return InteractionResult.FAIL;
+        }
         Level level = ctx.getLevel();
         BlockEntity blockEntity = level.getBlockEntity(ctx.getClickedPos());
         ExDepotMod.LOGGER.info("You just clicked a {} on the {} side", blockEntity, level.isClientSide ? "client" : "server");
@@ -41,6 +48,7 @@ public class DepotConfiguratorWandItem extends Item {
             ExDepotMod.LOGGER.info("Capability is {}", depotCap.orElse(null));
             depotCap.ifPresent((IDepotCapability capability) -> {
                 addModSortingRules(capability, blockEntity);
+                EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.triggerUpdateFromServer(level, ctx.getPlayer().blockPosition());
             });
         }
         return InteractionResult.CONSUME;

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotSummary.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotSummary.java
@@ -16,7 +16,7 @@ public record ViewDepotSummary(@NotNull BlockPos loc, @NotNull String modId, boo
         Set<ModSortingRule> modRules = cap.getRules(ModSortingRule.class);
         Optional<String> modIdOptional = modRules.stream().map(ModSortingRule::getModId).findFirst();
         String modId = modIdOptional.orElse("");
-        boolean isSimpleDepot = modRules.size() == 1 && cap.size() == 1;
+        boolean isSimpleDepot = (modRules.size() == 1 && cap.size() == 1) || cap.size() == 0;
         ChestFullness chestFullness = ChestFullness.getChestFullness(chest);
         return new ViewDepotSummary(loc, modId, isSimpleDepot, chestFullness);
     }

--- a/src/main/java/bike/guyona/exdepot/network/ViewDepotsMessage.java
+++ b/src/main/java/bike/guyona/exdepot/network/ViewDepotsMessage.java
@@ -7,7 +7,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.PacketDistributor;
@@ -32,7 +35,7 @@ public class ViewDepotsMessage {
             ExDepotMod.LOGGER.warn("NO ONE sent a ViewDepotsMessage");
         } else {
             ctx.get().enqueueWork(() -> {
-                Vector<BlockEntity> nearbyChests = getLocalChests(sender);
+                Vector<BlockEntity> nearbyChests = getLocalChests(sender.level, sender.position());
                 List<ViewDepotSummary> depotSummaries = new ArrayList<>();
                 for (BlockEntity chest : nearbyChests) {
                     chest.getCapability(DEPOT_CAPABILITY, Direction.UP).ifPresent((cap) -> {
@@ -45,18 +48,18 @@ public class ViewDepotsMessage {
         ctx.get().setPacketHandled(true);
     }
 
-    private static Vector<BlockEntity> getLocalChests(ServerPlayer player){
+    public static Vector<BlockEntity> getLocalChests(Level level, Vec3 playerPos){
         Vector<BlockEntity> chests = new Vector<>();
+        ChunkPos chunk = new ChunkPos(new BlockPos(playerPos));
         int chunkDist = (ExDepotConfig.storeRange.get() / CHUNK_SIZE) + 1;
-        ExDepotMod.LOGGER.debug("Storage range is {} blocks, or {} chunks", ExDepotConfig.storeRange.get(), chunkDist);
-        for (int chunkX = player.chunkPosition().x-chunkDist; chunkX <= player.chunkPosition().x+chunkDist; chunkX++) {
-            for (int chunkZ = player.chunkPosition().z-chunkDist; chunkZ <= player.chunkPosition().z+chunkDist; chunkZ++) {
-                Collection<BlockEntity> entities = player.level.getChunk(chunkX, chunkZ).getBlockEntities().values();
+        for (int chunkX = chunk.x-chunkDist; chunkX <= chunk.x+chunkDist; chunkX++) {
+            for (int chunkZ = chunk.z-chunkDist; chunkZ <= chunk.z+chunkDist; chunkZ++) {
+                Collection<BlockEntity> entities = level.getChunk(chunkX, chunkZ).getBlockEntities().values();
                 for (BlockEntity entity:entities) {
                     LazyOptional<IDepotCapability> lazyDepot = entity.getCapability(DEPOT_CAPABILITY, Direction.UP);
                     lazyDepot.ifPresent((depotCap) -> {
                         BlockPos chestPos = entity.getBlockPos();
-                        if (player.position().distanceToSqr(chestPos.getX(), chestPos.getY(), chestPos.getZ()) < ExDepotConfig.storeRange.get()*ExDepotConfig.storeRange.get()) {
+                        if (playerPos.distanceToSqr(chestPos.getX(), chestPos.getY(), chestPos.getZ()) < ExDepotConfig.storeRange.get()*ExDepotConfig.storeRange.get()) {
                             chests.add(entity);
                         }
                     });


### PR DESCRIPTION
* Before, the wand let you see the depot configuration for nearby depots, but the information only updated once every second. Now, The server will push depot updates to nearby wand holders.
* Fixed an issue that showed an asterisk for empty depot configuration.