### PR TITLE
Make runnable on server

### DIFF
--- a/src/main/java/bike/guyona/exdepot/ExDepotMod.java
+++ b/src/main/java/bike/guyona/exdepot/ExDepotMod.java
@@ -1,8 +1,6 @@
 package bike.guyona.exdepot;
 
 import bike.guyona.exdepot.capabilities.CapabilityEventHandler;
-import bike.guyona.exdepot.client.particles.DepositingItemParticleProvider;
-import bike.guyona.exdepot.client.particles.ViewDepotParticleProvider;
 import bike.guyona.exdepot.config.ExDepotConfig;
 import bike.guyona.exdepot.items.AutoDepotConfiguratorWandItem;
 import bike.guyona.exdepot.client.keys.KeybindHandler;
@@ -26,7 +24,6 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
-import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -165,15 +162,6 @@ public class ExDepotMod {
     @SubscribeEvent
     static void onCommonSetup(FMLCommonSetupEvent event) {
         LOGGER.info("First: I am on side {}, second: Update log4j to >= 2.16", EffectiveSide.get());
-    }
-
-    // TODO: The docs are insistent that this code be isolated in a client-only area.
-    //  For now, Imma trust that if the SERVER emits a PARTICLE registration event, it's ready to throw down some voodoo to make that happen.
-    // https://docs.minecraftforge.net/en/1.19.x/gameeffects/particles/#particleprovider
-    @SubscribeEvent
-    static void registerParticleProviders(RegisterParticleProvidersEvent event) {
-        event.register(DEPOSITING_ITEM_PARTICLE_TYPE.get(), new DepositingItemParticleProvider());
-        event.register(VIEW_DEPOT_PARTICLE_TYPE.get(), new ViewDepotParticleProvider());
     }
 
     @SubscribeEvent

--- a/src/main/java/bike/guyona/exdepot/ExDepotMod.java
+++ b/src/main/java/bike/guyona/exdepot/ExDepotMod.java
@@ -23,7 +23,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
-import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -162,10 +161,5 @@ public class ExDepotMod {
     @SubscribeEvent
     static void onCommonSetup(FMLCommonSetupEvent event) {
         LOGGER.info("First: I am on side {}, second: Update log4j to >= 2.16", EffectiveSide.get());
-    }
-
-    @SubscribeEvent
-    static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
-        KeybindHandler.onRegisterKeyMappings(event);
     }
 }

--- a/src/main/java/bike/guyona/exdepot/client/ModInit.java
+++ b/src/main/java/bike/guyona/exdepot/client/ModInit.java
@@ -1,0 +1,20 @@
+package bike.guyona.exdepot.client;
+
+import bike.guyona.exdepot.ExDepotMod;
+import bike.guyona.exdepot.Ref;
+import bike.guyona.exdepot.client.particles.DepositingItemParticleProvider;
+import bike.guyona.exdepot.client.particles.ViewDepotParticleProvider;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+public class ModInit {
+    // https://docs.minecraftforge.net/en/1.19.x/gameeffects/particles/#particleprovider
+    @SubscribeEvent
+    static void registerParticleProviders(RegisterParticleProvidersEvent event) {
+        event.register(ExDepotMod.DEPOSITING_ITEM_PARTICLE_TYPE.get(), new DepositingItemParticleProvider());
+        event.register(ExDepotMod.VIEW_DEPOT_PARTICLE_TYPE.get(), new ViewDepotParticleProvider());
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/ModInit.java
+++ b/src/main/java/bike/guyona/exdepot/client/ModInit.java
@@ -2,9 +2,11 @@ package bike.guyona.exdepot.client;
 
 import bike.guyona.exdepot.ExDepotMod;
 import bike.guyona.exdepot.Ref;
+import bike.guyona.exdepot.client.keys.KeybindHandler;
 import bike.guyona.exdepot.client.particles.DepositingItemParticleProvider;
 import bike.guyona.exdepot.client.particles.ViewDepotParticleProvider;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -16,5 +18,10 @@ public class ModInit {
     static void registerParticleProviders(RegisterParticleProvidersEvent event) {
         event.register(ExDepotMod.DEPOSITING_ITEM_PARTICLE_TYPE.get(), new DepositingItemParticleProvider());
         event.register(ExDepotMod.VIEW_DEPOT_PARTICLE_TYPE.get(), new ViewDepotParticleProvider());
+    }
+
+    @SubscribeEvent
+    static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
+        KeybindHandler.onRegisterKeyMappings(event);
     }
 }

--- a/src/main/java/bike/guyona/exdepot/client/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/client/events/EventHandler.java
@@ -3,7 +3,7 @@ package bike.guyona.exdepot.client.events;
 import bike.guyona.exdepot.Ref;
 import bike.guyona.exdepot.client.DepositItemsJuice;
 import bike.guyona.exdepot.items.DepotConfiguratorWandBase;
-import bike.guyona.exdepot.network.viewdepots.ViewDepotsCacheWhisperer;
+import bike.guyona.exdepot.client.network.viewdepots.ViewDepotsCacheWhisperer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraftforge.api.distmarker.Dist;

--- a/src/main/java/bike/guyona/exdepot/client/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/client/events/EventHandler.java
@@ -1,0 +1,37 @@
+package bike.guyona.exdepot.client.events;
+
+import bike.guyona.exdepot.Ref;
+import bike.guyona.exdepot.client.DepositItemsJuice;
+import bike.guyona.exdepot.items.DepotConfiguratorWandBase;
+import bike.guyona.exdepot.network.viewdepots.ViewDepotsCacheWhisperer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.ArrayList;
+
+@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
+public class EventHandler {
+    public static final DepositItemsJuice JUICER = new DepositItemsJuice();
+    public static final ViewDepotsCacheWhisperer VIEW_DEPOTS_CACHE_WHISPERER = new ViewDepotsCacheWhisperer();
+
+    @SubscribeEvent
+    static void onClientTick(TickEvent.ClientTickEvent event) {
+        JUICER.handleClientTick();
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null && DepotConfiguratorWandBase.isWand(player.getMainHandItem().getItem())) {
+            if (isIngame() && VIEW_DEPOTS_CACHE_WHISPERER.isUpdateDue()) {
+                VIEW_DEPOTS_CACHE_WHISPERER.triggerUpdateFromClient();
+            }
+        }else if (VIEW_DEPOTS_CACHE_WHISPERER.isActive()) {
+            VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(new ArrayList<>());
+        }
+    }
+
+    private static boolean isIngame() {
+        return Minecraft.getInstance().level != null;
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/items/GuiDepotConfiguratorWandItem.java
+++ b/src/main/java/bike/guyona/exdepot/client/items/GuiDepotConfiguratorWandItem.java
@@ -1,0 +1,33 @@
+package bike.guyona.exdepot.client.items;
+
+import bike.guyona.exdepot.capabilities.IDepotCapability;
+import bike.guyona.exdepot.client.gui.DepotRulesScreen;
+import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResult;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.util.LazyOptional;
+
+import static bike.guyona.exdepot.capabilities.DepotCapabilityProvider.DEPOT_CAPABILITY;
+
+public class GuiDepotConfiguratorWandItem {
+    public static InteractionResult handleGuiConfigure(boolean isClientSide, Player player, BlockEntity target) {
+        if (!isClientSide) {
+            return InteractionResult.CONSUME;
+        }
+        if (target == null) {
+            player.playSound(ConfigureDepotResult.NO_SELECTION.getSound(), 1,1);
+            return InteractionResult.CONSUME;
+        }
+        LazyOptional<IDepotCapability> depotCap = target.getCapability(DEPOT_CAPABILITY, Direction.UP);
+        if (!depotCap.isPresent()) {
+            player.playSound(ConfigureDepotResult.WHAT_IS_THAT.getSound(), 1,1);
+            return InteractionResult.CONSUME;
+        }
+        Minecraft.getInstance().setScreen(new DepotRulesScreen(null));
+        player.playSound(ConfigureDepotResult.SUCCESS.getSound(), 1,1);
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/network/configuredepot/ConfigureDepotResponse.java
+++ b/src/main/java/bike/guyona/exdepot/client/network/configuredepot/ConfigureDepotResponse.java
@@ -1,0 +1,17 @@
+package bike.guyona.exdepot.client.network.configuredepot;
+
+import bike.guyona.exdepot.ExDepotMod;
+import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResult;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+
+public class ConfigureDepotResponse {
+    public static void playConfigureDepotSound(ConfigureDepotResult configureDepotResult) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) {
+            ExDepotMod.LOGGER.error("Impossible: got an ingame-only network event while no player was loaded.");
+            return;
+        }
+        Minecraft.getInstance().player.playSound(configureDepotResult.getSound(), 1,1);
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/network/deposititems/DepositItemsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/client/network/deposititems/DepositItemsResponse.java
@@ -1,0 +1,23 @@
+package bike.guyona.exdepot.client.network.deposititems;
+
+import bike.guyona.exdepot.ExDepotMod;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.Map;
+
+import static bike.guyona.exdepot.client.events.EventHandler.JUICER;
+
+public class DepositItemsResponse {
+    public static void queueDepositJuice(Map<BlockPos, List<ItemStack>> sortingResults) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) {
+            ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
+            return;
+        }
+        JUICER.enqueueDepositEvent(sortingResults);
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/network/viewdepots/ViewDepotsCacheWhisperer.java
+++ b/src/main/java/bike/guyona/exdepot/client/network/viewdepots/ViewDepotsCacheWhisperer.java
@@ -1,0 +1,96 @@
+package bike.guyona.exdepot.client.network.viewdepots;
+
+import bike.guyona.exdepot.client.particles.ViewDepotParticle;
+import bike.guyona.exdepot.network.viewdepots.ViewDepotSummary;
+import bike.guyona.exdepot.network.viewdepots.ViewDepotsMessage;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static bike.guyona.exdepot.ExDepotMod.NETWORK_INSTANCE;
+
+public class ViewDepotsCacheWhisperer {
+    public static final int VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS = 1000;
+    private static long lastUpdatedViewableConfigs = 0;
+    private List<ViewDepotSummary> depotSummaries = new ArrayList<>();
+    private final List<ViewDepotParticle> depotParticles = new ArrayList<>();
+
+    public boolean isUpdateDue() {
+        return System.currentTimeMillis() > lastUpdatedViewableConfigs + VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
+    }
+
+    public void setUpdated() {
+        lastUpdatedViewableConfigs = System.currentTimeMillis();
+    }
+
+    // Clients know they want to ping occasionally for updates.
+    public void triggerUpdateFromClient() {
+        NETWORK_INSTANCE.sendToServer(new ViewDepotsMessage());
+        this.setUpdated();
+    }
+
+    public boolean isActive() {
+        return depotSummaries.size() > 0;
+    }
+
+    public boolean areSummariesChanged(@NotNull List<ViewDepotSummary> depotSummaries) {
+        if (this.depotSummaries.size() != depotSummaries.size()) {
+            return true;
+        }
+        sortSummaries(depotSummaries);
+        for (int i=0; i<depotSummaries.size(); i++) {
+            if (!this.depotSummaries.get(i).equals(depotSummaries.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void resetParticleLifetimes() {
+        for (ViewDepotParticle particle : depotParticles) {
+            particle.resetAge();
+        }
+    }
+
+    public void replaceParticles(@NotNull List<ViewDepotSummary> depotSummaries) {
+        // Out with the old
+        for (ViewDepotParticle particle : depotParticles) {
+            particle.remove();
+        }
+        depotParticles.clear();
+        this.depotSummaries.clear();
+        // In with the new
+        Minecraft minecraft = Minecraft.getInstance();
+        this.depotSummaries = depotSummaries;
+        sortSummaries(this.depotSummaries);
+        for (ViewDepotSummary depotSummary : this.depotSummaries) {
+            ViewDepotParticle particle = new ViewDepotParticle(
+                    minecraft.level,
+                    depotSummary.loc().x,
+                    depotSummary.loc().y,
+                    depotSummary.loc().z,
+                    depotSummary.modId(),
+                    depotSummary.isSimpleDepot(),
+                    depotSummary.chestFullness()
+            );
+            depotParticles.add(particle);
+            minecraft.particleEngine.add(particle);
+        }
+        // Just in case server triggered the update, thereby bypassing the typical procedure.
+        this.setUpdated();
+    }
+
+    private void sortSummaries(@NotNull List<ViewDepotSummary> depotSummaries) {
+        depotSummaries.sort((ViewDepotSummary pos1, ViewDepotSummary pos2) -> {
+            if (pos1.loc().y != pos2.loc().y) {
+                return Double.compare(pos1.loc().y, pos2.loc().y);
+            } else if (pos1.loc().x != pos2.loc().x) {
+                return Double.compare(pos1.loc().x, pos2.loc().x);
+            } else {
+                return Double.compare(pos1.loc().z, pos2.loc().z);
+            }
+        });
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/network/viewdepots/ViewDepotsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/client/network/viewdepots/ViewDepotsResponse.java
@@ -1,0 +1,24 @@
+package bike.guyona.exdepot.client.network.viewdepots;
+
+import bike.guyona.exdepot.ExDepotMod;
+import bike.guyona.exdepot.client.events.EventHandler;
+import bike.guyona.exdepot.network.viewdepots.ViewDepotSummary;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+
+import java.util.List;
+
+public class ViewDepotsResponse {
+    public static void updateViewDepotsCache(List<ViewDepotSummary> depotSummaries) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) {
+            ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
+            return;
+        }
+        if (EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.areSummariesChanged(depotSummaries)) {
+            EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(depotSummaries);
+        } else {
+            EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.resetParticleLifetimes();
+        }
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/network/wandmodechanged/ChangeWandModeResponse.java
+++ b/src/main/java/bike/guyona/exdepot/client/network/wandmodechanged/ChangeWandModeResponse.java
@@ -1,0 +1,17 @@
+package bike.guyona.exdepot.client.network.wandmodechanged;
+
+import bike.guyona.exdepot.ExDepotMod;
+import bike.guyona.exdepot.sounds.SoundEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+
+public class ChangeWandModeResponse {
+    public static void playWandModeSwitchSound(){
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) {
+            ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
+            return;
+        }
+        Minecraft.getInstance().player.playSound(SoundEvents.WAND_SWITCH.get(), 1, 1);
+    }
+}

--- a/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
+++ b/src/main/java/bike/guyona/exdepot/client/particles/ViewDepotParticle.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-import static bike.guyona.exdepot.network.viewdepots.ViewDepotsCacheWhisperer.VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
+import static bike.guyona.exdepot.client.network.viewdepots.ViewDepotsCacheWhisperer.VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
 import static net.minecraft.SharedConstants.TICKS_PER_SECOND;
 
 

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -4,7 +4,6 @@ import bike.guyona.exdepot.Ref;
 import bike.guyona.exdepot.capabilities.DepotCapabilityProvider;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
 import bike.guyona.exdepot.helpers.ModSupportHelpers;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;

--- a/src/main/java/bike/guyona/exdepot/events/EventHandler.java
+++ b/src/main/java/bike/guyona/exdepot/events/EventHandler.java
@@ -3,18 +3,15 @@ package bike.guyona.exdepot.events;
 import bike.guyona.exdepot.Ref;
 import bike.guyona.exdepot.capabilities.DepotCapabilityProvider;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
-import bike.guyona.exdepot.client.DepositItemsJuice;
 import bike.guyona.exdepot.helpers.ModSupportHelpers;
-import bike.guyona.exdepot.items.DepotConfiguratorWandBase;
-import bike.guyona.exdepot.network.viewdepots.ViewDepotsCacheWhisperer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -22,7 +19,6 @@ import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,26 +27,11 @@ import static bike.guyona.exdepot.ExDepotMod.*;
 import static bike.guyona.exdepot.capabilities.DepotCapabilityProvider.DEPOT_CAPABILITY;
 
 
-@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid = Ref.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.DEDICATED_SERVER)
 public class EventHandler {
-    public static final DepositItemsJuice JUICER = new DepositItemsJuice();
-    public static final ViewDepotsCacheWhisperer VIEW_DEPOTS_CACHE_WHISPERER = new ViewDepotsCacheWhisperer();
     // playerID -> BlockPos -> depotCacheCompoundTag.
     // Technically key should include level, but one player can't leftclick a block in two levels in one tick.
     private static final Map<Integer, Map<BlockPos, CompoundTag>> pickedUpDepotCache = new HashMap<>();
-
-    @SubscribeEvent
-    static void onClientTick(TickEvent.ClientTickEvent event) {
-        JUICER.handleClientTick();
-        LocalPlayer player = Minecraft.getInstance().player;
-        if (player != null && DepotConfiguratorWandBase.isWand(player.getMainHandItem().getItem())) {
-            if (isIngame() && VIEW_DEPOTS_CACHE_WHISPERER.isUpdateDue()) {
-                VIEW_DEPOTS_CACHE_WHISPERER.triggerUpdateFromClient();
-            }
-        }else if (VIEW_DEPOTS_CACHE_WHISPERER.isActive()) {
-            VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(new ArrayList<>());
-        }
-    }
 
     //Clear DepotCap from previous tick.
     @SubscribeEvent
@@ -113,10 +94,6 @@ public class EventHandler {
         placedEntity.getCapability(DepotCapabilityProvider.DEPOT_CAPABILITY).ifPresent((IDepotCapability capability) -> {
             capability.deserializeNBT(capabilityCache);
         });
-    }
-
-    private static boolean isIngame() {
-        return Minecraft.getInstance().level != null;
     }
 
     public static CompoundTag getDepotCache(BlockPos pos, int playerId) {

--- a/src/main/java/bike/guyona/exdepot/items/AutoDepotConfiguratorWandItem.java
+++ b/src/main/java/bike/guyona/exdepot/items/AutoDepotConfiguratorWandItem.java
@@ -1,9 +1,8 @@
 package bike.guyona.exdepot.items;
 
 import bike.guyona.exdepot.ExDepotMod;
-import bike.guyona.exdepot.capabilities.DefaultDepotCapability;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
-import bike.guyona.exdepot.events.EventHandler;
+import bike.guyona.exdepot.client.events.EventHandler;
 import bike.guyona.exdepot.helpers.ModSupportHelpers;
 import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResponse;
 import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResult;

--- a/src/main/java/bike/guyona/exdepot/items/AutoDepotConfiguratorWandItem.java
+++ b/src/main/java/bike/guyona/exdepot/items/AutoDepotConfiguratorWandItem.java
@@ -2,10 +2,10 @@ package bike.guyona.exdepot.items;
 
 import bike.guyona.exdepot.ExDepotMod;
 import bike.guyona.exdepot.capabilities.IDepotCapability;
-import bike.guyona.exdepot.client.events.EventHandler;
 import bike.guyona.exdepot.helpers.ModSupportHelpers;
 import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResponse;
 import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResult;
+import bike.guyona.exdepot.network.viewdepots.ViewDepotsCacheWhisperer;
 import bike.guyona.exdepot.sortingrules.SortingRuleProvider;
 import bike.guyona.exdepot.sortingrules.mod.ModSortingRule;
 import net.minecraft.core.Direction;
@@ -88,7 +88,7 @@ public class AutoDepotConfiguratorWandItem extends DepotConfiguratorWandBase {
                 e.getCapability(DEPOT_CAPABILITY, Direction.UP).ifPresent(cap -> cap.copyFrom(depotCap.orElse(null)));
             }
         }
-        EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.triggerUpdateFromServer(level, player.blockPosition());
+        ViewDepotsCacheWhisperer.triggerUpdateFromServer(level, player.blockPosition());
         NETWORK_INSTANCE.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new ConfigureDepotResponse(ConfigureDepotResult.SUCCESS));
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/bike/guyona/exdepot/items/GuiDepotConfiguratorWandItem.java
+++ b/src/main/java/bike/guyona/exdepot/items/GuiDepotConfiguratorWandItem.java
@@ -1,11 +1,6 @@
 package bike.guyona.exdepot.items;
 
 import bike.guyona.exdepot.ExDepotMod;
-import bike.guyona.exdepot.capabilities.IDepotCapability;
-import bike.guyona.exdepot.client.gui.DepotRulesScreen;
-import bike.guyona.exdepot.network.configuredepot.ConfigureDepotResult;
-import net.minecraft.client.Minecraft;
-import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -14,12 +9,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static bike.guyona.exdepot.capabilities.DepotCapabilityProvider.DEPOT_CAPABILITY;
 
 public class GuiDepotConfiguratorWandItem extends DepotConfiguratorWandBase {
     public GuiDepotConfiguratorWandItem(Properties properties) {
@@ -45,7 +38,7 @@ public class GuiDepotConfiguratorWandItem extends DepotConfiguratorWandBase {
         }
         Level level = ctx.getLevel();
         BlockEntity blockEntity = level.getBlockEntity(ctx.getClickedPos());
-        return this.handleGuiConfigure(level.isClientSide, player, blockEntity);
+        return bike.guyona.exdepot.client.items.GuiDepotConfiguratorWandItem.handleGuiConfigure(level.isClientSide, player, blockEntity);
     }
 
     @Override
@@ -56,24 +49,6 @@ public class GuiDepotConfiguratorWandItem extends DepotConfiguratorWandBase {
             ExDepotMod.LOGGER.error("Impossible: GuiWand received a use event meant for something else.");
             return new InteractionResultHolder<>(InteractionResult.FAIL, itemstack);
         }
-        return new InteractionResultHolder<>(this.handleGuiConfigure(level.isClientSide, player, null), itemstack);
-    }
-
-    private InteractionResult handleGuiConfigure(boolean isClientSide, Player player, BlockEntity target) {
-        if (!isClientSide) {
-            return InteractionResult.CONSUME;
-        }
-        if (target == null) {
-            player.playSound(ConfigureDepotResult.NO_SELECTION.getSound(), 1,1);
-            return InteractionResult.CONSUME;
-        }
-        LazyOptional<IDepotCapability> depotCap = target.getCapability(DEPOT_CAPABILITY, Direction.UP);
-        if (!depotCap.isPresent()) {
-            player.playSound(ConfigureDepotResult.WHAT_IS_THAT.getSound(), 1,1);
-            return InteractionResult.CONSUME;
-        }
-        Minecraft.getInstance().setScreen(new DepotRulesScreen(null));
-        player.playSound(ConfigureDepotResult.SUCCESS.getSound(), 1,1);
-        return InteractionResult.SUCCESS;
+        return new InteractionResultHolder<>(bike.guyona.exdepot.client.items.GuiDepotConfiguratorWandItem.handleGuiConfigure(level.isClientSide, player, null), itemstack);
     }
 }

--- a/src/main/java/bike/guyona/exdepot/network/configuredepot/ConfigureDepotResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/configuredepot/ConfigureDepotResponse.java
@@ -1,9 +1,6 @@
 package bike.guyona.exdepot.network.configuredepot;
 
-import bike.guyona.exdepot.ExDepotMod;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.network.NetworkEvent;
@@ -28,12 +25,7 @@ public class ConfigureDepotResponse {
     public static void handle(ConfigureDepotResponse obj, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-                Player player = Minecraft.getInstance().player;
-                if (player == null) {
-                    ExDepotMod.LOGGER.error("Impossible: got an ingame-only network event while no player was loaded.");
-                    return;
-                }
-                Minecraft.getInstance().player.playSound(obj.configureDepotResult.getSound(), 1,1);
+                bike.guyona.exdepot.client.network.configuredepot.ConfigureDepotResponse.playConfigureDepotSound(obj.configureDepotResult);
             });
         });
         ctx.get().setPacketHandled(true);

--- a/src/main/java/bike/guyona/exdepot/network/deposititems/DepositItemsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/deposititems/DepositItemsResponse.java
@@ -1,8 +1,5 @@
 package bike.guyona.exdepot.network.deposititems;
 
-import bike.guyona.exdepot.ExDepotMod;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
@@ -15,8 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-
-import static bike.guyona.exdepot.client.events.EventHandler.JUICER;
 
 public class DepositItemsResponse {
     Map<BlockPos, List<ItemStack>> sortingResults;
@@ -53,12 +48,7 @@ public class DepositItemsResponse {
     public static void handle(DepositItemsResponse obj, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-                LocalPlayer player = Minecraft.getInstance().player;
-                if (player == null) {
-                    ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
-                    return;
-                }
-                JUICER.enqueueDepositEvent(obj.sortingResults);
+                bike.guyona.exdepot.client.network.deposititems.DepositItemsResponse.queueDepositJuice(obj.sortingResults);
             });
         });
         ctx.get().setPacketHandled(true);

--- a/src/main/java/bike/guyona/exdepot/network/deposititems/DepositItemsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/deposititems/DepositItemsResponse.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static bike.guyona.exdepot.events.EventHandler.JUICER;
+import static bike.guyona.exdepot.client.events.EventHandler.JUICER;
 
 public class DepositItemsResponse {
     Map<BlockPos, List<ItemStack>> sortingResults;

--- a/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsCacheWhisperer.java
+++ b/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsCacheWhisperer.java
@@ -1,15 +1,12 @@
 package bike.guyona.exdepot.network.viewdepots;
 
-import bike.guyona.exdepot.client.particles.ViewDepotParticle;
 import bike.guyona.exdepot.config.ExDepotConfig;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,29 +15,10 @@ import java.util.Vector;
 import static bike.guyona.exdepot.ExDepotMod.NETWORK_INSTANCE;
 import static bike.guyona.exdepot.capabilities.DepotCapabilityProvider.DEPOT_CAPABILITY;
 
-// Only meant to be used on client, although it can be used from server to update the client.
+// The vast majority of this class is in the client code.
 public class ViewDepotsCacheWhisperer {
-    public static final int VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS = 1000;
-    private static long lastUpdatedViewableConfigs = 0;
-    private List<ViewDepotSummary> depotSummaries = new ArrayList<>();
-    private final List<ViewDepotParticle> depotParticles = new ArrayList<>();
-
-    public boolean isUpdateDue() {
-        return System.currentTimeMillis() > lastUpdatedViewableConfigs + VIEW_DEPOTS_CACHE_REFRESH_INTERVAL_MS;
-    }
-
-    public void setUpdated() {
-        lastUpdatedViewableConfigs = System.currentTimeMillis();
-    }
-
-    // Clients know they want to ping occasionally for updates.
-    public void triggerUpdateFromClient() {
-        NETWORK_INSTANCE.sendToServer(new ViewDepotsMessage());
-        this.setUpdated();
-    }
-
     // Server can send an immediate update if things change.
-    public void triggerUpdateFromServer(Level depotLevel, BlockPos depotPos) {
+    public static void triggerUpdateFromServer(Level depotLevel, BlockPos depotPos) {
         depotLevel.players()
                 .stream()
                 .filter(player -> player.distanceToSqr(depotPos.getX(), depotPos.getY(), depotPos.getZ()) < Math.pow(ExDepotConfig.storeRange.get(), 2))
@@ -55,68 +33,5 @@ public class ViewDepotsCacheWhisperer {
                     }
                     NETWORK_INSTANCE.send(PacketDistributor.PLAYER.with(() -> player), new ViewDepotsResponse(depotSummariesNearPlayer));
                 });
-    }
-
-    public boolean isActive() {
-        return depotSummaries.size() > 0;
-    }
-
-    public boolean areSummariesChanged(@NotNull List<ViewDepotSummary> depotSummaries) {
-        if (this.depotSummaries.size() != depotSummaries.size()) {
-            return true;
-        }
-        sortSummaries(depotSummaries);
-        for (int i=0; i<depotSummaries.size(); i++) {
-            if (!this.depotSummaries.get(i).equals(depotSummaries.get(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public void resetParticleLifetimes() {
-        for (ViewDepotParticle particle : depotParticles) {
-            particle.resetAge();
-        }
-    }
-
-    public void replaceParticles(@NotNull List<ViewDepotSummary> depotSummaries) {
-        // Out with the old
-        for (ViewDepotParticle particle : depotParticles) {
-            particle.remove();
-        }
-        depotParticles.clear();
-        this.depotSummaries.clear();
-        // In with the new
-        Minecraft minecraft = Minecraft.getInstance();
-        this.depotSummaries = depotSummaries;
-        sortSummaries(this.depotSummaries);
-        for (ViewDepotSummary depotSummary : this.depotSummaries) {
-            ViewDepotParticle particle = new ViewDepotParticle(
-                    minecraft.level,
-                    depotSummary.loc().x,
-                    depotSummary.loc().y,
-                    depotSummary.loc().z,
-                    depotSummary.modId(),
-                    depotSummary.isSimpleDepot(),
-                    depotSummary.chestFullness()
-            );
-            depotParticles.add(particle);
-            minecraft.particleEngine.add(particle);
-        }
-        // Just in case server triggered the update, thereby bypassing the typical procedure.
-        this.setUpdated();
-    }
-
-    private void sortSummaries(@NotNull List<ViewDepotSummary> depotSummaries) {
-        depotSummaries.sort((ViewDepotSummary pos1, ViewDepotSummary pos2) -> {
-            if (pos1.loc().y != pos2.loc().y) {
-                return Double.compare(pos1.loc().y, pos2.loc().y);
-            } else if (pos1.loc().x != pos2.loc().x) {
-                return Double.compare(pos1.loc().x, pos2.loc().x);
-            } else {
-                return Double.compare(pos1.loc().z, pos2.loc().z);
-            }
-        });
     }
 }

--- a/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsResponse.java
@@ -1,11 +1,7 @@
 package bike.guyona.exdepot.network.viewdepots;
 
-import bike.guyona.exdepot.ExDepotMod;
-import bike.guyona.exdepot.client.events.EventHandler;
 import bike.guyona.exdepot.helpers.ChestFullness;
 import com.mojang.math.Vector3d;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
@@ -54,16 +50,7 @@ public class ViewDepotsResponse {
     public static void handle(ViewDepotsResponse obj, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-                LocalPlayer player = Minecraft.getInstance().player;
-                if (player == null) {
-                    ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
-                    return;
-                }
-                if (EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.areSummariesChanged(obj.depotSummaries)) {
-                    EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.replaceParticles(obj.depotSummaries);
-                } else {
-                    EventHandler.VIEW_DEPOTS_CACHE_WHISPERER.resetParticleLifetimes();
-                }
+                bike.guyona.exdepot.client.network.viewdepots.ViewDepotsResponse.updateViewDepotsCache(obj.depotSummaries);
             });
         });
         ctx.get().setPacketHandled(true);

--- a/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/viewdepots/ViewDepotsResponse.java
@@ -1,12 +1,11 @@
 package bike.guyona.exdepot.network.viewdepots;
 
 import bike.guyona.exdepot.ExDepotMod;
-import bike.guyona.exdepot.events.EventHandler;
+import bike.guyona.exdepot.client.events.EventHandler;
 import bike.guyona.exdepot.helpers.ChestFullness;
 import com.mojang.math.Vector3d;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;

--- a/src/main/java/bike/guyona/exdepot/network/wandmodechanged/ChangeWandModeResponse.java
+++ b/src/main/java/bike/guyona/exdepot/network/wandmodechanged/ChangeWandModeResponse.java
@@ -1,10 +1,6 @@
 package bike.guyona.exdepot.network.wandmodechanged;
 
-import bike.guyona.exdepot.ExDepotMod;
 import bike.guyona.exdepot.items.DepotConfiguratorWandBase;
-import bike.guyona.exdepot.sounds.SoundEvents;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
@@ -30,12 +26,7 @@ public class ChangeWandModeResponse {
     public static void handle(ChangeWandModeResponse obj, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
             DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-                LocalPlayer player = Minecraft.getInstance().player;
-                if (player == null) {
-                    ExDepotMod.LOGGER.error("Impossible: the client doesn't have a player");
-                    return;
-                }
-                Minecraft.getInstance().player.playSound(SoundEvents.WAND_SWITCH.get(), 1, 1);
+                bike.guyona.exdepot.client.network.wandmodechanged.ChangeWandModeResponse.playWandModeSwitchSound();
             });
         });
         ctx.get().setPacketHandled(true);


### PR DESCRIPTION
Y'all already know that Minecraft ships a hamstrung binary for servers, meaning they hack a bunch of code out of the server binary instead of delivering the same stuff you get on the client.

I didn't pay strict attention to the code structure rules that result from that delivery mechanism.

This PR fixes that, so a dedicated Minecraft server can still load and run my mod.